### PR TITLE
Add MkDocs docs and GH Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install mkdocs
+      - name: Deploy
+        run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 *.csv
+site

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,3 @@
+# About
+
+nuMCMC is distributed under the MIT License. The source code is available on [GitHub](https://github.com/MarianoChaves/MCMC).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# nuMCMC Documentation
+
+Welcome to the **nuMCMC** documentation site. This library provides a lightweight C++ implementation of Markov Chain Monte Carlo (MCMC) algorithms inspired by the Python `emcee` package.
+
+## Features
+- Easy‑to‑use API
+- Parallel execution
+- Checkpointing support
+- Minimal dependencies
+
+See the [project README on GitHub](https://github.com/MarianoChaves/MCMC/blob/main/README.md) for installation instructions.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,20 @@
+# Quick Start
+
+This section outlines a minimal example of running nuMCMC.
+
+```cpp
+#include "MCMC.h"
+
+// Define your log probability
+double logProbability(const std::vector<double>& params) {
+    double x = params[0];
+    return -0.5 * x * x; // standard normal
+}
+
+int main() {
+    numcmc::MCMC sampler(1, 10); // dimension=1, 10 walkers
+    sampler.setLogProbabilityFunction(logProbability);
+    sampler.run(5000);
+    auto samples = sampler.getSamples();
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: nuMCMC
+site_description: Documentation for the nuMCMC C++ library
+site_author: nuMCMC Contributors
+
+nav:
+  - Home: index.md
+  - Quick Start: quickstart.md
+  - About: about.md
+
+docs_dir: docs
+
+plugins: []


### PR DESCRIPTION
## Summary
- add MkDocs configuration and docs
- configure `.gitignore` for docs
- add GitHub Actions workflow for deploying docs to GitHub Pages

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_6869ce82798c8321843f617edae0565a